### PR TITLE
Added support REPO beta upgrades, items, valuables, and museum map

### DIFF
--- a/Core/APSaveData.cs
+++ b/Core/APSaveData.cs
@@ -20,10 +20,10 @@ namespace RepoAP
         public List<string> monsterSoulsGathered = new List<string>();
         public List<int> shopItemsPurchased = new List<int>();
         public long shopStockSlotData;
-        public int shopStockRecieved;
-        public Dictionary<long, int> itemsRecieved = new Dictionary<long, int>();
+        public int shopStockReceived;
+        public Dictionary<long, int> itemsReceived = new Dictionary<long, int>();
         public Dictionary<string, bool> levelsUnlocked = new Dictionary<string, bool>();
-        public int itemRecievedIndex = 0;
+        public int itemReceivedIndex = 0;
         public Dictionary<long, ItemInfo> shopItemsScouted = new Dictionary<long, ItemInfo>();
         public JArray pellysRequired = new JArray();
         public bool pellySpawning;
@@ -143,53 +143,53 @@ namespace RepoAP
             return shopLocs;
         }
 
-        public static void AddItemRecieved(long itemId)
+        public static void AddItemReceived(long itemId)
         {
             if (Plugin.connection.session == null)
             {
                 return;
             }
             //If Key Exists, add 1
-            if (saveData.itemsRecieved.ContainsKey(itemId))
+            if (saveData.itemsReceived.ContainsKey(itemId))
             {
-                saveData.itemsRecieved[itemId]++;
+                saveData.itemsReceived[itemId]++;
                 
             }
             //If not, set to 1
             else
             {
-                saveData.itemsRecieved.Add(itemId, 1);
+                saveData.itemsReceived.Add(itemId, 1);
             }
 
             //Increase Item Index
-            saveData.itemRecievedIndex++;
+            saveData.itemReceivedIndex++;
 
             //Save
             ES3.Save<APSaveData>(saveKey, saveData, es3Settings);
             //Debug.Log("Saved " + itemId);
         }
-        public static int GetItemRecievedIndex()
+        public static int GetItemReceivedIndex()
         {
             if (Plugin.connection.session == null)
             {
                 return 0;
             }
-            return ES3.Load<APSaveData>(saveKey, es3Settings).itemRecievedIndex;
+            return ES3.Load<APSaveData>(saveKey, es3Settings).itemReceivedIndex;
         }
 
-        public static void AddStockRecieved()
+        public static void AddStockReceived()
         {
             if (Plugin.connection.session == null)
             {
                 return;
             }
-            if (saveData.itemsRecieved.ContainsKey(ItemData.AddBaseId(18)))
+            if (saveData.itemsReceived.ContainsKey(ItemData.AddBaseId(ItemData.shopStockID)))
             {
-                saveData.shopStockRecieved = saveData.itemsRecieved[ItemData.AddBaseId(18)];
+                saveData.shopStockReceived = saveData.itemsReceived[ItemData.AddBaseId(ItemData.shopStockID)];
             }
             else
             {
-                saveData.shopStockRecieved = 0;
+                saveData.shopStockReceived = 0;
             }
             //Save
             ES3.Save<APSaveData>(saveKey, saveData, es3Settings);
@@ -201,7 +201,7 @@ namespace RepoAP
             Plugin.ShopItemsAvailable = new List<int>();
             Plugin.ShopItemsBought = GetShopLocationsChecked();
 
-            for (int i = 1; i <= (APSave.saveData.shopStockSlotData * (APSave.saveData.shopStockRecieved + 1)); i++)
+            for (int i = 1; i <= (APSave.saveData.shopStockSlotData * (APSave.saveData.shopStockReceived + 1)); i++)
             {
                 //Debug.Log($"Stocking item {i}");
                 if (!Plugin.ShopItemsBought.Contains(i))
@@ -211,16 +211,16 @@ namespace RepoAP
             }
         }
 
-        public static Dictionary<long, int> GetItemsRecieved()
+        public static Dictionary<long, int> GetItemsReceived()
         {
             if (Plugin.connection.session == null)
             {
                 return null;
             }
-            return ES3.Load<APSaveData>(saveKey, es3Settings).itemsRecieved;
+            return ES3.Load<APSaveData>(saveKey, es3Settings).itemsReceived;
         }
 
-        public static void AddLevelRecieved(string levelName)
+        public static void AddLevelReceived(string levelName)
         {
             if (Plugin.connection.session == null)
             {
@@ -232,13 +232,13 @@ namespace RepoAP
             }
             else
             {
-                Debug.LogError(levelName + " has already been recieved!");
+                Debug.LogError(levelName + " has already been received!");
             }
 
             ES3.Save<APSaveData>(saveKey, saveData, es3Settings);
         }
 
-        public static Dictionary<string,bool> GetLevelsRecieved()
+        public static Dictionary<string,bool> GetLevelsReceived()
         {
             if (Plugin.connection.session == null)
             {
@@ -316,7 +316,7 @@ namespace RepoAP
         //For when the player extracts a Valuable
         public static void AddValuableGathered(string name)
         {
-            name = name.Replace("Arctic ", "").Replace("Wizard ", "").Replace("Valuable ", "").Replace("(Clone)", "");
+            name = LocationData.GetBaseName(name);
             if (Plugin.connection.session == null)
             {
                 return;
@@ -331,7 +331,7 @@ namespace RepoAP
         //For when the player extracts a Monster Soul
         public static void AddMonsterSoulGathered(string name)
         {
-            name = name.Replace("(Clone)", "");
+            name = LocationData.GetBaseName(name);
             if (Plugin.connection.session == null)
             {
                 return;
@@ -364,7 +364,6 @@ namespace RepoAP
             }
 
             var pellys = saveData.pellysRequired;
-            List<string> levels = new List<string>() {"Manor", "Arctic", "Wizard" };
             
             //Check if Pelly Hunt is Complete
             Debug.Log("Pellys Required:");
@@ -380,7 +379,7 @@ namespace RepoAP
 
             foreach (string pelly in pellys)
             {
-                foreach(string level in levels)
+                foreach(string level in LocationNames.all_levels_short)
                 {
                     if (!saveData.pellysGathered.Exists(x => x.Contains(level) && x.Contains(pelly)))
                     {

--- a/Core/ArchipelagoConnection.cs
+++ b/Core/ArchipelagoConnection.cs
@@ -289,7 +289,7 @@ namespace RepoAP
 
                 var itemDisplayName = itemName + " (" + networkItem.ItemName + ") at index " + pendingItem.index;
 
-                if (APSave.GetItemRecievedIndex() > pendingItem.index)
+                if (APSave.GetItemReceivedIndex() > pendingItem.index)
                 {
                     incomingItems.TryDequeue(out _);
                     //TunicRandomizer.Tracker.SetCollectedItem(itemName, false);
@@ -300,16 +300,16 @@ namespace RepoAP
 
                 //CrabFile.current.SetInt($"randomizer processed item index {pendingItem.index}", 1);
                 Debug.Log("ItemHandler " + networkItem.ItemId);
-                APSave.AddItemRecieved(networkItem.ItemId);
+                APSave.AddItemReceived(networkItem.ItemId);
 
                 List<Level> nonGameLevels = new List<Level> { RunManager.instance.levelMainMenu, RunManager.instance.levelLobby, RunManager.instance.levelLobbyMenu };
 
-                //Make sure player isnt in a non-game Level
+                //Make sure player isn't in a non-game Level
                 if (!nonGameLevels.Contains( RunManager.instance.levelCurrent))
                 {
                     ItemData.AddItemToInventory(networkItem.ItemId,false);
 
-                    Plugin.customRPCManager.CallFocusTextRPC($"Recieved {itemName}", Plugin.customRPCManagerObject);
+                    Plugin.customRPCManager.CallFocusTextRPC($"Received {itemName}", Plugin.customRPCManagerObject);
                 }
 
                 //ItemSwapData.GetItem(networkItem.ItemId);

--- a/Items/ItemData.cs
+++ b/Items/ItemData.cs
@@ -9,17 +9,17 @@ namespace RepoAP
 {
     class ItemData
     {
-        static int baseID = 75912022;
+        const int baseID = 75912022;
+        public const int shopStockID = 20;
         public static void AddItemToInventory(long itemId, bool repeatedAdditions)
         {
             
             string itemName = IdToItemName(RemoveBaseId(itemId));
             Debug.Log("Adding Item To Inventory: " + RemoveBaseId(itemId) + " : " + itemName);
 
-            List<string> levelNames = new List<string> { LocationNames.mcjannek, LocationNames.headman_manor, LocationNames.swiftbroom };
-            if (levelNames.Contains(itemName))
+            if (LocationNames.all_levels.Contains(itemName))
             {
-                APSave.AddLevelRecieved(itemName);
+                APSave.AddLevelReceived(itemName);
             }
             else if (itemName == ItemNames.shopStock)
             {
@@ -27,7 +27,7 @@ namespace RepoAP
                 {
                     return;
                 }*/
-                APSave.AddStockRecieved();
+                APSave.AddStockReceived();
                 APSave.UpdateAvailableItems();
             }
             else
@@ -46,8 +46,9 @@ namespace RepoAP
                 case 0: itemName = LocationNames.swiftbroom; break;
                 case 1: itemName = LocationNames.headman_manor; break;
                 case 2: itemName = LocationNames.mcjannek; break;
+                case 3: itemName = LocationNames.museum; break;
                 //Upgrades
-                case 10: itemName = ItemNames.upgreadHealth; break;
+                case 10: itemName = ItemNames.upgradeHealth; break;
                 case 11: itemName = ItemNames.upgradeStrength; break;
                 case 12: itemName = ItemNames.upgradeRange; break;
                 case 13: itemName = ItemNames.upgradeSprintSpeed; break;
@@ -55,7 +56,9 @@ namespace RepoAP
                 case 15: itemName = ItemNames.upgradePlayerCount; break;
                 case 16: itemName = ItemNames.upgradeDoubleJump; break;
                 case 17: itemName = ItemNames.upgradeTumbleLaunch; break;
-                case 18: itemName = ItemNames.shopStock; break;
+                case 18: itemName = ItemNames.upgradeCrouchRest; break;
+                case 19: itemName = ItemNames.upgradeTumbleWings; break;
+                case shopStockID: itemName = ItemNames.shopStock; break;
             }
 
             return itemName;

--- a/Items/ItemNames.cs
+++ b/Items/ItemNames.cs
@@ -8,7 +8,8 @@ namespace RepoAP
 {
     public static class ItemNames
     {
-
+        static public string cartCannon = "Item Cart Cannon";
+        static public string cartLaser = "Item Cart Laser";
         static public string cartMed = "Item Cart Medium";
         static public string cartSmall = "Item Cart Small";
         static public string droneBattery = "Item Drone Battery";
@@ -16,6 +17,7 @@ namespace RepoAP
         static public string droneIndestructible = "Item Drone Indestructible";
         static public string droneRoll = "Item Drone Torque";
         static public string droneZeroGrav = "Item Drone Zero Gravity";
+        static public string duckBucket = "Item Duck Bucket";
         static public string extractTracker = "Item Extraction Tracker";
         static public string grenadeDuctTape = "Item Grenade Duct Taped";
         static public string grenade = "Item Grenade Explosive";
@@ -23,7 +25,10 @@ namespace RepoAP
         static public string grenadeShockwave = "Item Grenade Shockwave";
         static public string grenadeStun = "Item Grenade Stun";
         static public string gunPistol = "Item Gun Handgun";
+        static public string gunLaser = "Item Gun Laser";
+        static public string gunShockwave = "Item Gun Shockwave";
         static public string gunShotgun = "Item Gun Shotgun";
+        static public string gunStun = "Item Gun Stun";
         static public string gunTranq = "Item Gun Tranq";
         static public string healthPackLarge = "Item Health Pack Large";
         static public string healthPackMed = "Item Health Pack Medium";
@@ -32,23 +37,27 @@ namespace RepoAP
         static public string fryingPan = "Item Melee Frying Pan";
         static public string inflatableHammer = "Item Melee Inflatable Hammer";
         static public string sledgeHammer = "Item Melee Sledge Hammer";
+        static public string stunBaton = "Item Melee Stun Baton";
         static public string sword = "Item Melee Sword";
         static public string mineExplosive = "Item Mine Explosive";
         static public string mineShockwave = "Item Mine Shockwave";
         static public string mineStun = "Item Mine Stun";
         static public string zeroGravOrb = "Item Orb Zero Gravity";
+        static public string phaseBridge = "Item Phase Bridge";
         static public string powerCrystal = "Item Power Crystal";
         static public string rubberDuck = "Item Rubber Duck";
         static public string upgradePlayerCount = "Item Upgrade Map Player Count";
+        static public string upgradeCrouchRest = "Item Upgrade Player Crouch Rest";
         static public string upgradeStamina = "Item Upgrade Player Energy";
         static public string upgradeDoubleJump = "Item Upgrade Player Extra Jump";
         static public string upgradeRange = "Item Upgrade Player Grab Range";
         static public string upgradeStrength = "Item Upgrade Player Grab Strength";
-        static public string upgreadHealth = "Item Upgrade Player Health";
+        static public string upgradeHealth = "Item Upgrade Player Health";
         static public string upgradeSprintSpeed = "Item Upgrade Player Sprint Speed";
         static public string upgradeTumbleLaunch = "Item Upgrade Player Tumble Launch";
+        static public string upgradeTumbleWings = "Item Upgrade Player Tumble Wings";
         static public string valuableTracker = "Item Valuable Tracker";
         static public string apItem = "Item Upgrade AP Item";
         static public string shopStock = "Progressive Shop Stock";
-    }
+   }
 }

--- a/Items/LevelLockPatch.cs
+++ b/Items/LevelLockPatch.cs
@@ -10,17 +10,18 @@ namespace RepoAP
     [HarmonyPatch(typeof(RunManager), "SetRunLevel")]
     class LevelLockPatch
     {
+        static internal int levelIndex = -1;
         [HarmonyPostfix]
         static void SetRunLevelPre(RunManager __instance)
         {
-            if (APSave.GetLevelsRecieved().Count == 0 || Plugin.connection.session == null)
+            if (APSave.GetLevelsReceived().Count == 0 || Plugin.connection.session == null)
             {
                 Debug.LogError("No Levels found in Save!");
                 return;
             }
 
             //Get what levels the player has unlocked
-            var levels = APSave.GetLevelsRecieved();
+            var levels = APSave.GetLevelsReceived();
 
             //Add levels to a list
             List<string> levelList = new();
@@ -30,8 +31,12 @@ namespace RepoAP
                 levelList.Add(level.Key);
             }
 
-            //Choose a random level from list
-            var levelChoiceName = levelList[Random.RandomRangeInt(0, levelList.Count)];
+            //Choose a random level from list at first
+            //And than cycle through the available levels
+            if (levelIndex < 0) levelIndex = Random.RandomRangeInt(0, levelList.Count);
+            else levelIndex = (levelIndex + 1) % levelList.Count;
+
+            var levelChoiceName = levelList[levelIndex];
             Level levelChoice = null;
             Debug.Log("Setting level to " + levelChoiceName);
             //Set level to choice
@@ -45,9 +50,11 @@ namespace RepoAP
                 {
                     Debug.Log(level.NarrativeName + " != " + levelChoiceName);
                 }
+
                 //Headman Manor : Level - Manor
                 //Swiftbroom Academy : Level - Wizard
                 //McJannek Station : Level - Arctic
+                //Museum of Human Art : Level - Museum
                 //Debug.Log($"{level.NarrativeName} : {level.name}");
             }
             __instance.levelCurrent = levelChoice;

--- a/Items/StartRunWithAPItemsPatch.cs
+++ b/Items/StartRunWithAPItemsPatch.cs
@@ -20,9 +20,9 @@ namespace RepoAP.Items
             }
 
             Debug.Log("Start Run With AP Items");
-            var itemsRecieved = APSave.GetItemsRecieved();
+            var itemsReceived = APSave.GetItemsReceived();
 
-            foreach (var item in itemsRecieved)
+            foreach (var item in itemsReceived)
             {
                 for (int i = 0; i < item.Value; i++)
                 {

--- a/Locations/ExtractionSendCheckPatch.cs
+++ b/Locations/ExtractionSendCheckPatch.cs
@@ -16,68 +16,84 @@ namespace RepoAP
 
 	class ExtractSendCheck
     {
-		static int totalHaul;
+		//static int totalHaul;
+	    private static void CheckValuable(GameObject valuableObject)
+	    {
+            Debug.Log($"Extracting {valuableObject.name}");
+            if (valuableObject && valuableObject.GetComponent<PhysGrabObject>())
+            {
+               //totalHaulField.SetValue(RoundDirector.instance, totalHaul + (int)valuableObject.GetComponent<ValuableObject>().dollarValueCurrent);
+
+               //If extracted item is a pelly, send a corresponding check
+               if (valuableObject.name.Contains("Pelly"))
+               {
+                  Plugin.connection.ActivateCheck(LocationData.PellyNameToID(valuableObject.name + RunManager.instance.levelCurrent.name));
+                  APSave.AddPellyGathered(valuableObject.name + RunManager.instance.levelCurrent.name);
+               }
+               else if (valuableObject.name.Contains("Soul"))
+               {
+                  long id = LocationData.MonsterSoulNameToID(valuableObject.name);
+                  if (0 != LocationData.RemoveBaseId(id))
+                  {
+                     Plugin.connection.ActivateCheck(id);
+                     APSave.AddMonsterSoulGathered(valuableObject.name);
+                  }
+               }
+               else if (valuableObject.name.Contains("Valuable"))
+               {
+                  long id = LocationData.ValuableNameToID(valuableObject.name);
+                  if (0 != LocationData.RemoveBaseId(id))
+                  {
+                     Plugin.connection.ActivateCheck(id);
+                     APSave.AddValuableGathered(valuableObject.name);
+                  }
+
+               }
+            }
+        }
+
 		public static void Send(FieldInfo totalHaulField)
         {
-			totalHaul = (int)totalHaulField.GetValue(RoundDirector.instance);
+			//totalHaul = (int)totalHaulField.GetValue(RoundDirector.instance);
 
 			//Only Run if singleplayer or host machine
 			if (SemiFunc.IsMasterClientOrSingleplayer())
 			{
-				if (RoundDirector.instance.dollarHaulList.Count == 0)
-				{
-					return;
-				}
-				foreach (var valuableObject in RoundDirector.instance.dollarHaulList)
-				{
-					Debug.Log($"Extracting {valuableObject.name}");
-					if (valuableObject && valuableObject.GetComponent<PhysGrabObject>())
-					{
-						totalHaulField.SetValue(RoundDirector.instance, totalHaul + (int)valuableObject.GetComponent<ValuableObject>().dollarValueCurrent);
-
-						//If extracted item is a pelly, send a corresponding check
-						if (valuableObject.name.Contains("Pelly"))
-						{
-							Plugin.connection.ActivateCheck(LocationData.PellyNameToID(valuableObject.name + RunManager.instance.levelCurrent.name));
-							APSave.AddPellyGathered(valuableObject.name + RunManager.instance.levelCurrent.name);
-						}
-						else if (valuableObject.name.Contains("Soul"))
-						{
-							long id = LocationData.MonsterSoulNameToID(valuableObject.name);
-							if (0 != LocationData.RemoveBaseId(id))
-							{
-								Plugin.connection.ActivateCheck(id);
-								APSave.AddMonsterSoulGathered(valuableObject.name);
-							}
-						}
-						else if (valuableObject.name.Contains("Valuable"))
-						{
-							long id = LocationData.ValuableNameToID(valuableObject.name);
-							if (0 != LocationData.RemoveBaseId(id))
-							{
-								Plugin.connection.ActivateCheck(id);
-								APSave.AddValuableGathered(valuableObject.name);
-							}
-
-						}
-					}
-				}
+                if (RoundDirector.instance.dollarHaulList.Count > 0)
+                {
+                    foreach (var valuableObject in RoundDirector.instance.dollarHaulList)
+                    {
+                        CheckValuable(valuableObject);
+                    }
+                }
 			}
 		}
+
+	    public static void SendFirst(FieldInfo totalHaulField)
+	    {
+            //totalHaul = (int)totalHaulField.GetValue(RoundDirector.instance);
+
+            if (SemiFunc.IsMasterClientOrSingleplayer())
+            {
+                if (RoundDirector.instance.dollarHaulList.Count > 0)
+                {
+                    CheckValuable(RoundDirector.instance.dollarHaulList[0]);
+                }
+            }
+        }
     }
 
 
     [HarmonyPatch(typeof(ExtractionPoint))]
     class ExtractionSendCheckPatch
     {
-
 		static FieldInfo field = AccessTools.Field(typeof(RoundDirector), "totalHaul");
 		static int totalHaul;
 
         [HarmonyPrefix, HarmonyPatch("DestroyAllPhysObjectsInHaulList")]
         static void ExtractAllPatch()
         {
-			//Exit it not connected to an AP Server
+			//Exit if not connected to an AP Server
 			if (Plugin.connection == null)
             {
 				return;
@@ -88,13 +104,13 @@ namespace RepoAP
 		[HarmonyPrefix, HarmonyPatch("DestroyTheFirstPhysObjectsInHaulList")]
 		static void ExtractFirstPatch()
 		{
-			//Exit it not connected to an AP Server
+			//Exit if not connected to an AP Server
 			if (Plugin.connection == null)
 			{
 				return;
 			}
 
-			ExtractSendCheck.Send(field);
+			ExtractSendCheck.SendFirst(field);
 		}
 	}
 }

--- a/Locations/LocationData.cs
+++ b/Locations/LocationData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -9,7 +10,9 @@ namespace RepoAP
 {
     static class LocationData
     {
-        static int baseID = 75912022;
+        const int baseID = 75912022;
+        const int valuableOffset = 200;
+        const int monsterOffset = 500;
         static Dictionary<long, string> idToName;
         static Dictionary<string, long> nameToId;
         static long[] ids;
@@ -22,34 +25,32 @@ namespace RepoAP
 
             }
         }
+
+        public static string GetBaseName(string name)
+        {
+            name = name.Replace("Valuable ", "").Replace("(Clone)", "");
+            foreach (string level in LocationNames.all_levels_short)
+            {
+                name = name.Replace($"{level} ", "");
+            }
+            return name;
+        }
+      
         public static long MonsterSoulNameToID(string name)
         {
             long id = 0;
-            name = name.Replace("(Clone)", "");
-            switch (name)
-            {
-                case LocationNames.animal_soul: id = 300; break;
-                case LocationNames.duck_soul: id = 301; break;
-                case LocationNames.bowtie_soul: id = 302; break;
-                case LocationNames.chef_soul: id = 303; break;
-                case LocationNames.clown_soul: id = 304; break;
-                case LocationNames.headman_soul: id = 305; break;
-                case LocationNames.hidden_soul: id = 306; break;
-                case LocationNames.huntsman_soul: id = 307; break;
-                case LocationNames.mentalist_soul: id = 308; break;
-                case LocationNames.reaper_soul: id = 309; break;
-                case LocationNames.robe_soul: id = 310; break;
-                case LocationNames.rugrat_soul: id = 311; break;
-                case LocationNames.shadow_child_soul: id = 312; break;
-                case LocationNames.spewer_soul: id = 313; break;
-                case LocationNames.trudge_soul: id = 314; break;
-                case LocationNames.upscream_soul: id = 315; break;
-            }
+            name = GetBaseName(name);
 
+            id = LocationNames.all_monster_souls.IndexOf(name);
 
-            if (id == 0)
+            if (id == -1)
             {
                 Debug.Log($"{name}'s id not found");
+                id = 0;
+            }
+            else
+            {
+                id += monsterOffset;
             }
 
             return baseID + id;
@@ -57,80 +58,18 @@ namespace RepoAP
         public static long ValuableNameToID(string name)
         {
             long id = 0;
-            name = name.Replace("Arctic ", "").Replace("Wizard ", "").Replace("Valuable ", "").Replace("(Clone)","");
-            switch(name)
-            {
-                case LocationNames.diamond: id = 200; break;
-                case LocationNames.ring: id = 201; break;
-                case LocationNames.goblet: id = 202; break;
-                case LocationNames.ocarina: id = 203; break;
-                case LocationNames.pocket_watch: id = 204; break;
-                case LocationNames.uranium_mug: id = 205; break;
-                case LocationNames.crown: id = 206; break;
-                case LocationNames.doll: id = 207; break;
-                case LocationNames.explosive_barrel: id = 208; break;
-                case LocationNames.frog_toy: id = 209; break;
-                case LocationNames.gem_box: id = 210; break;
-                case LocationNames.globe: id = 211; break;
-                case LocationNames.money: id = 212; break;
-                case LocationNames.monkey: id = 213; break;
-                case LocationNames.uranium_plate: id = 214; break;
-                case LocationNames.small_vase: id = 215; break;
-                case LocationNames.champagne: id = 216; break;
-                case LocationNames.clown_doll: id = 217; break;
-                case LocationNames.radio: id = 218; break;
-                case LocationNames.ship_in_a_bottle: id = 219; break;
-                case LocationNames.trophy: id = 220; break;
-                case LocationNames.vase: id = 221; break;
-                case LocationNames.tv: id = 222; break;
-                case LocationNames.large_vase: id = 223; break;
-                case LocationNames.animal_crate: id = 224; break;
-                case LocationNames.bonsai: id = 225; break;
-                case LocationNames.music_box: id = 226; break;
-                case LocationNames.gramophone: id = 227; break;
-                case LocationNames.rhino: id = 228; break;
-                case LocationNames.scream_doll: id = 229; break;
-                case LocationNames.grand_piano: id = 230; break;
-                case LocationNames.harp: id = 231; break;
-                case LocationNames.painting: id = 232; break;
-                case LocationNames.grandfather_clock: id = 233; break;
-                case LocationNames.dinosaur_skeleton: id = 234; break;
-                case LocationNames.golden_statue: id = 235; break;
-                case LocationNames.desktop_computer: id = 236; break;
-                case LocationNames.fan: id = 237; break;
-                case LocationNames.sample: id = 238; break;
-                case LocationNames.big_sample: id = 239; break;
-                case LocationNames.flamethrower: id = 240; break;
-                case LocationNames.science_station: id = 241; break;
-                case LocationNames.server: id = 242; break;
-                case LocationNames.printer: id = 243; break;
-                case LocationNames.hdd: id = 244; break;
-                case LocationNames.ice_saw: id = 245; break;
-                case LocationNames.laptop: id = 246; break;
-                case LocationNames.propane: id = 247; break;
-                case LocationNames.sample_pack: id = 248; break;
-                case LocationNames.guitar: id = 249; break;
-                case LocationNames.sample_cooler: id = 250; break;
-                case LocationNames.leg_ice: id = 251; break;
-                case LocationNames.skeleton_ice: id = 252; break;
-                case LocationNames.chomp_book: id = 253; break;
-                case LocationNames.love_potion: id = 254; break;
-                case LocationNames.cube_of_knowledge: id = 255; break;
-                case LocationNames.staff: id = 256; break;
-                case LocationNames.large_sword: id = 257; break;
-                case LocationNames.broom: id = 258; break;
-                case LocationNames.hourglass: id = 259; break;
-                case LocationNames.master_potion: id = 260; break;
-                case LocationNames.goblin_head: id = 261; break;
-                case LocationNames.griffin: id = 262; break;
-                case LocationNames.power_crystal: id = 263; break;
-            }
+            name = GetBaseName(name);
 
+            id = LocationNames.all_valuables.IndexOf(name);
 
-
-            if(id == 0)
+            if (id == -1)
             {
                 Debug.Log($"{name}'s id not found");
+                id = 0;
+            }
+            else
+            {
+                id += valuableOffset;
             }
 
             return baseID + id;
@@ -138,33 +77,26 @@ namespace RepoAP
         public static long PellyNameToID(string name)
         {
             int offset = 100;
-
-            //Add Pelly Level Type Offset
-            if (name.Contains("Wizard")) //Swiftbroom Academy
+            int idx = 1;
+            foreach (string level in LocationNames.all_levels_short)
             {
-                offset += 1;
-            }
-            else if (name.Contains("Manor"))
-            {
-                offset += 4;
-            }
-            else if (name.Contains("Arctic")) //McJannek Station
-            {
-                offset += 7;
+                if( name.Contains(level) )
+                { 
+                    offset += idx;
+                    break;
+                }
+                idx += 3;
             }
 
-            //Add Pelly Type Offset
-            if (name.Contains("Standard"))
+            idx = 0;
+            foreach (string pelly in LocationNames.all_pellys)
             {
-                offset += 0;
-            }
-            else if (name.Contains("Glass"))
-            {
-                offset += 1;
-            }
-            else if (name.Contains("Gold"))
-            {
-                offset += 2;
+               if (name.Contains(pelly))
+               {
+                   offset += idx;
+                   break;
+               }
+               idx++;
             }
 
             return baseID + offset;
@@ -182,8 +114,6 @@ namespace RepoAP
             {
                 return 0;
             }
-
-
         }
 
         public static long RemoveBaseId(long id)

--- a/Locations/LocationNames.cs
+++ b/Locations/LocationNames.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Runtime.ConstrainedExecution;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -10,9 +11,9 @@ namespace RepoAP
     class LocationNames
     {
         //Pelly Names
-        static public string standard_pelly = "Standard Pelly";
-        static public string glass_pelly = "Glass Pelly";
-        static public string gold_pelly = "Gold Pelly";
+        static public string standard_pelly = "Standard";
+        static public string glass_pelly = "Glass";
+        static public string gold_pelly = "Gold";
 
         //Shop Location Names
         static public string upgrade_pur = "Upgrade Purchase";
@@ -21,6 +22,7 @@ namespace RepoAP
         static public string swiftbroom = "Swiftbroom Academy ";
         static public string headman_manor = "Headman Manor ";
         static public string mcjannek = "McJannek Station ";
+        static public string museum = "Museum of Human Art ";
 
         //---- Valuables ----
         //-- All --
@@ -95,6 +97,58 @@ namespace RepoAP
         public const string griffin = "Griffin Statue";
         public const string power_crystal = "Power Crystal";
 
+        //-- Museum of Human Art --
+        public const string egg = "Egg";
+        public const string car = "Car";
+        public const string banana_bow = "Banana Bow";
+        public const string boombox = "Boombox";
+        public const string cool_brain = "Cool brain";
+        public const string cubic_tower = "Cubic Tower";
+        public const string fish = "Fish";
+        public const string silverfish = "Silverfish";
+        public const string goldfish = "Goldfish";
+        public const string golden_swirl = "Golden Swirl";
+        public const string pacifier = "Pacifier";
+        public const string baby_head = "Baby Head";
+        public const string monkeybox = "MonkeyBox";
+        public const string flesh_blob = "Flesh Blob";
+        public const string tooth = "Tooth";
+        public const string goldtooth = "GoldTooth";
+        public const string toast = "Toast";
+        public const string horse = "Horse";
+        public const string blender = "Blender";
+        public const string mug_deluxe = "Uranium Mug Deluxe";
+        public const string gumball = "Gumball";
+        public const string traffic_light = "Traffic Light";
+        public const string milk = "Milk";
+        public const string handface = "Handface";
+        public const string gem_burger = "Gem Burger";
+        public const string wire_figure = "Wire Figure";
+        public const string rubendoll = "Ruben Doll";
+
+        public static readonly ReadOnlyCollection<string> all_pellys = new ReadOnlyCollection<string>(new List<string>()
+        {
+           standard_pelly,
+           glass_pelly,
+           gold_pelly
+        });
+
+        public static readonly ReadOnlyCollection<string> all_levels_short = new ReadOnlyCollection<string>(new List<string>()
+        {
+           "Wizard",
+           "Manor",
+           "Arctic",
+           "Museum"
+        });
+
+        public static readonly ReadOnlyCollection<string> all_levels = new ReadOnlyCollection<string>(new List<string>
+        {
+            swiftbroom,
+            headman_manor,
+            mcjannek,
+            museum
+        });
+
         public static readonly ReadOnlyCollection<string> all_valuables = new ReadOnlyCollection<string>(new List<string>
         {
             diamond,
@@ -114,14 +168,12 @@ namespace RepoAP
             small_vase,
             champagne,
             clown_doll,
-            radio,
-            ship_in_a_bottle,
             trophy,
             vase,
-            tv,
             large_vase,
             animal_crate,
             bonsai,
+
             music_box,
             gramophone,
             rhino,
@@ -132,6 +184,10 @@ namespace RepoAP
             grandfather_clock,
             dinosaur_skeleton,
             golden_statue,
+            tv,
+            radio,
+            ship_in_a_bottle,
+
             desktop_computer,
             fan,
             explosive_barrel,
@@ -150,6 +206,7 @@ namespace RepoAP
             sample_cooler,
             leg_ice,
             skeleton_ice,
+
             chomp_book,
             love_potion,
             cube_of_knowledge,
@@ -161,6 +218,34 @@ namespace RepoAP
             goblin_head,
             griffin,
             power_crystal,
+            
+            egg,
+            car,
+            banana_bow,
+            boombox,
+            cool_brain,
+            cubic_tower,
+            fish,
+            silverfish,
+            goldfish,
+            golden_swirl,
+            pacifier,
+            baby_head,
+            monkeybox,
+            flesh_blob,
+            tooth,
+            goldtooth,
+            toast,
+            horse,
+            blender,
+            mug_deluxe,
+            gumball,
+            traffic_light,
+            milk,
+            handface,
+            gem_burger,
+            wire_figure,
+            rubendoll
         });
 
         // ---- Monster Souls ----

--- a/Locations/PhysGrabObjectPatch.cs
+++ b/Locations/PhysGrabObjectPatch.cs
@@ -11,8 +11,13 @@ namespace RepoAP
         [HarmonyPatch(nameof(PhysGrabObject.GrabStarted)),HarmonyPostfix]
         static void OrbInfoTextEnabler(PhysGrabObject __instance)
         {
-            if (!__instance.gameObject.name.Contains("soul")) { return; }
-            SemiFunc.UIItemInfoText(null, __instance.gameObject.name);
-        }
+            string name = __instance.gameObject.name;
+
+            if (name.Contains("Soul") || name.Contains("Valuable"))
+            {
+                name = LocationData.GetBaseName(name);
+                SemiFunc.UIItemInfoText(null, name);
+            }
+      }
     }
 }

--- a/TestPatches.cs
+++ b/TestPatches.cs
@@ -138,7 +138,7 @@ namespace RepoAP
             }
             if (Input.GetKeyDown(KeyCode.F9))
             {
-                Debug.Log(APSave.saveData.shopStockRecieved);
+                Debug.Log(APSave.saveData.shopStockReceived);
             }
         }
     } 


### PR DESCRIPTION
-Updated mod to support additional content from the REPO beta. This includes strings for the new items, upgrades, and valuables, as well as support for the museum map.

-Added new `SendFirst()` method for `DestroyTheFirstPhysObjectsInHaulList` patch at extraction time to only check the first valuable in the haul list. This function is being called for each valuable sent, so the original behavior would check each valuable multiple times.

-Added text when holding items for Souls and Valuables. 

-Refactor of switch statements in `LocationData.cs`. These statements can be replaced by a single call to `ReadOnlyCollection.IndexOf()`, making adding new valuables and souls less tedious.

-Added a new static method to `LocationData.cs` to get the base name of a `GameObject` without map adjectives or `(Clone)` postfix.

-Support for cycling through the available levels instead of choosing one at random. 

-A few other changes with the goal of reducing redundant data and code. 